### PR TITLE
chore: refactor templates and values

### DIFF
--- a/charts/telicent-core/charts/core-mesh/templates/_helpers.tpl
+++ b/charts/telicent-core/charts/core-mesh/templates/_helpers.tpl
@@ -43,67 +43,123 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Service principals
+Service names
 */}}
-{{- define "core-mesh.accessApiPrincipal" -}}
-{{- printf "cluster.local/ns/%s/sa/%s" .Release.Namespace .Values.accessApi.serviceAccountName }}
+
+{{- define "core-mesh.accessApiServiceName" -}}
+{{- .Values.accessApi.serviceName | default (printf "%s-%s" .Release.Name "access-api") | quote }}
+{{- end -}}
+
+{{- define "core-mesh.accessUiServiceName" -}}
+{{- .Values.accessUi.serviceName | default (printf "%s-%s" .Release.Name "access-ui") | quote }}
+{{- end -}}
+
+{{- define "core-mesh.queryUiServiceName" -}}
+{{- .Values.queryUi.serviceName | default (printf "%s-%s" .Release.Name "query-ui") | quote }}
+{{- end -}}
+
+{{- define "core-mesh.searchUiServiceName" -}}
+{{- .Values.searchUi.serviceName | default (printf "%s-%s" .Release.Name "search-ui") | quote }}
+{{- end -}}
+
+{{- define "core-mesh.graphUiServiceName" -}}
+{{- .Values.graphUi.serviceName | default (printf "%s-%s" .Release.Name "graph-ui") | quote }}
+{{- end -}}
+
+{{- define "core-mesh.graphServerServiceName" -}}
+{{- .Values.graphServer.serviceName | default (printf "%s-%s" $.Release.Name "smart-cache-graph") | quote }}
 {{- end }}
 
+{{- define "core-mesh.searchApiServiceName" -}}
+{{- .Values.searchApi.serviceName | default (printf "%s-%s" $.Release.Name "smart-cache-search-api") | quote }}
+{{- end }}
+
+{{/*
+Service principals
+*/}}
 {{- define "core-mesh.ingressPrincipal" -}}
-{{- printf "cluster.local/ns/%s/sa/%s" .Values.ingress.namespace .Values.ingress.serviceAccountName }}
+{{- .Values.ingress.principal | default (printf "cluster.local/ns/%s/sa/%s" .Values.ingress.namespace "istio-ingress") | quote }}
 {{- end }}
 
 {{- define "core-mesh.graphServerPrincipal" -}}
-{{- printf "cluster.local/ns/%s/sa/%s" .Release.Namespace .Values.graphServer.serviceAccountName }}
+{{- .Values.graphServer.principal | default (printf "cluster.local/ns/%s/sa/%s-%s" .Release.Namespace .Release.Name "smart-cache-graph") quote }}
 {{- end }}
 
 {{- define "core-mesh.searchApiPrincipal" -}}
-{{- printf "cluster.local/ns/%s/sa/%s" .Release.Namespace .Values.searchApi.serviceAccountName }}
+{{- .Values.searchApi.principal | default (printf "cluster.local/ns/%s/sa/%s-%s" .Release.Namespace .Release.Name "smart-cache-search") | quote }}
 {{- end }}
 
 {{/*
 Selectors
 */}}
 {{- define "core-mesh.accessApiSelectors" -}}
-app.kubernetes.io/instance: {{ .Values.accessApi.instance }}
-app.kubernetes.io/name: {{ .Values.accessApi.name }}
-{{- end }}
+{{- if .Values.accessApi.selectors -}}
+{{ .Values.accessApi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: access-api
+{{- end -}}
+{{- end -}}
 
 {{- define "core-mesh.accessUiSelectors" -}}
-app.kubernetes.io/instance: {{ .Values.accessUi.instance }}
-app.kubernetes.io/name: {{ .Values.accessUi.name }}
-{{- end }}
+{{- if .Values.accessUi.selectors -}}
+{{ .Values.accessUi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: access-ui
+{{- end -}}
+{{- end -}}
 
 {{- define "core-mesh.graphServerSelectors" -}}
-app.kubernetes.io/instance: {{ .Values.graphServer.instance }}
-app.kubernetes.io/name: {{ .Values.graphServer.name }}
-{{- end }}
+{{- if .Values.graphServer.selectors -}}
+{{ .Values.graphServer.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: smart-cache-graph
+{{- end -}}
+{{- end -}}
 
-{{- define "core-mesh.querySelectors" -}}
-app.kubernetes.io/instance: {{ .Values.query.instance }}
-app.kubernetes.io/name: {{ .Values.query.name }}
-{{- end }}
+{{- define "core-mesh.queryUiSelectors" -}}
+{{- if .Values.queryUi.selectors -}}
+{{ .Values.queryUi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: query-ui
+{{- end -}}
+{{- end -}}
 
 {{- define "core-mesh.searchUiSelectors" -}}
-{{- if .Values.closedSourceDeployment }}
-app.kubernetes.io/instance: {{ .Values.searchUi.instance }}
-app.kubernetes.io/name: {{ .Values.searchUi.name }}
-{{- end }}
-{{- end }}
+{{- if .Values.enterprise }}
+{{- if .Values.searchUi.selectors -}}
+{{ .Values.searchUi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: search-ui
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{- define "core-mesh.graphUiSelectors" -}}
-{{- if .Values.closedSourceDeployment }}
-app.kubernetes.io/instance: {{ .Values.graphUi.instance }}
-app.kubernetes.io/name: {{ .Values.graphUi.name }}
-{{- end }}
-{{- end }}
+{{- if .Values.enterprise }}
+{{- if .Values.graphUi.selectors -}}
+{{ .Values.graphUi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: graph-ui
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{- define "core-mesh.searchApiSelectors" -}}
-{{- if .Values.closedSourceDeployment }}
-app.kubernetes.io/instance: {{ .Values.searchApi.instance }}
-app.kubernetes.io/name: {{ .Values.searchApi.name }}
-{{- end }}
-{{- end }}
+{{- if .Values.enterprise }}
+{{- if .Values.searchApi.selectors -}}
+{{ .Values.searchApi.selectors | toYaml }}
+{{- else -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: search-api
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Jwks URI

--- a/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/core-apps-to-search-api.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/core-apps-to-search-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-graph-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-graph-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-query-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-query-ui.yaml
@@ -17,4 +17,4 @@ spec:
               - GET
   selector:
     matchLabels:
-    {{- include "core-mesh.querySelectors" . | nindent 6 }}
+    {{- include "core-mesh.queryUiSelectors" . | nindent 6 }}

--- a/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-search-api.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-search-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-search-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/authorizationpolicy/ingress-to-search-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/access-api.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/access-api.yaml
@@ -19,6 +19,6 @@ spec:
         rewrite: /\2
     route:
     - destination:
-        host: {{ .Values.accessApi.serviceName }}
+        host: {{ include "core-mesh.accessApiServiceName" . }}
         port:
           number: {{ .Values.accessApi.port }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/access-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/access-ui.yaml
@@ -20,6 +20,6 @@ spec:
         prefix: /access/
     route:
     - destination:
-        host: {{ .Values.accessUi.serviceName }}
+        host: {{ include "core-mesh.accessUiServiceName" . }}
         port:
           number: {{ .Values.accessUi.port }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/graph-server.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/graph-server.yaml
@@ -17,7 +17,7 @@ spec:
       uri: /knowledge/sparql
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -27,7 +27,7 @@ spec:
       uri: /knowledge/query
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -37,7 +37,7 @@ spec:
       uri: /knowledge/graphql
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -47,7 +47,7 @@ spec:
       uri: /ontology/sparql
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -57,7 +57,7 @@ spec:
       uri: /ontology/query
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -67,7 +67,7 @@ spec:
       uri: /catalog/sparql
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}
   - match:
@@ -77,6 +77,6 @@ spec:
       uri: /catalog/query
     route:
     - destination:
-        host: {{ .Values.graphServer.serviceName }}
+        host: {{ include "core-mesh.graphServerServiceName" . }}
         port:
           number: {{ .Values.graphServer.port }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/graph-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/graph-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -21,7 +21,7 @@ spec:
         prefix: /graph/
     route:
     - destination:
-        host: {{ .Values.graphUi.serviceName }}
+        host: {{ include "core-mesh.graphUiServiceName" . }}
         port:
           number: {{ .Values.graphUi.port }}
 {{- end }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/query-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/query-ui.yaml
@@ -20,6 +20,6 @@ spec:
         prefix: /query/
     route:
     - destination:
-        host: {{ .Values.query.serviceName }}
+        host: {{ include "core-mesh.queryUiServiceName" . }}
         port:
-          number: {{ .Values.query.port }}
+          number: {{ .Values.queryUi.port }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/search-api.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/search-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -26,7 +26,7 @@ spec:
 
     route:
     - destination:
-        host: {{ .Values.searchApi.serviceName }}
+        host: {{ include "core-mesh.searchApiServiceName" . }}
         port:
           number: {{ .Values.searchApi.port }}
 {{- end }}

--- a/charts/telicent-core/charts/core-mesh/templates/virtualservice/search-ui.yaml
+++ b/charts/telicent-core/charts/core-mesh/templates/virtualservice/search-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.closedSourceDeployment }}
+{{- if .Values.enterprise }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -21,7 +21,7 @@ spec:
         prefix: /search/
     route:
     - destination:
-          host: {{ .Values.searchUi.serviceName }}
+          host: {{ include "core-mesh.searchUiServiceName" . }}
           port:
             number: {{ .Values.searchUi.port }}
 {{- end }}

--- a/charts/telicent-core/charts/core-mesh/values.yaml
+++ b/charts/telicent-core/charts/core-mesh/values.yaml
@@ -1,50 +1,50 @@
+global:
+  kafkaConfigProtocol: "SASL_SSL"
+  kafkaConfigMechanism: "SCRAM-SHA-512"
+  kafkaConfigUsername: "smart-cache"
+  kafkaConfigPassword: "PASSWORD"
+  appHostDomain: "APPS_DOMAIN"
+  authHostDomain: "AUTH_DOMAIN"
+  jwksUrl: "https://AUTH_DOMAIN/realms/core/protocol/openid-connect/certs"
+
 accessApi:
-  instance: access-api
-  name: access-api
   port: 8080
-  serviceAccountName: access-api
-  serviceName: access-api
+  # serviceName: access-api
+
 accessUi:
-  instance: access-ui
-  name: access-ui
   port: 8080
-  serviceName: access-ui
+  # serviceName: access-ui
+
 appsGateway: istio-system/gateways-apps
 appsHost: change.me.to.the.apps.host
 authnHost: change.me.to.the.authn.host
+
 jwksUri: ""
 jwtIssuer: ""
 fullnameOverride: ""
+
 graphServer:
-  instance: smart-cache-graph
-  name: smart-cache-graph
   port: 3030
-  serviceAccountName: smart-cache-graph
-  serviceName: smart-cache-graph
+  # serviceName: smart-cache-graph
+
 ingress:
   namespace: istio-system
-  serviceAccountName: istio-ingress
-nameOverride: ""
-query:
-  instance: query-ui
-  name: query-ui
-  port: 8080
-  serviceName: query-ui
 
-closedSourceDeployment: false
+nameOverride: ""
+queryUi:
+  port: 8080
+  # serviceName: query-ui
+
+enterprise: false
+
 searchUi:
-  instance: search-ui
-  name: search-ui
   port: 8080
-  serviceName: search-ui
+  # serviceName: search-ui
+
 graphUi:
-  instance: graph-ui
-  name: graph-ui
   port: 8080
-  serviceName: graph-ui
+  # serviceName: graph-ui
+
 searchApi:
-  instance: smart-cache-search
-  name: smart-cache-search-api
   port: 8181
-  serviceAccountName: smart-cache-search-api
-  serviceName: smart-cache-search-api
+  # serviceName: smart-cache-search-api


### PR DESCRIPTION
* Updates templates for selectors, service principals and service names to take into account that it will likely be deployed as a sub-chart of telicent-core.
* All can be overriden by the values file
* Change to "enterprise" instead of closedSourceRelease