### PR TITLE
fix: Add condition to `search` and `search-projector` sub-charts.

### DIFF
--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -52,9 +52,11 @@ dependencies:
   - name: search
     version: "^0.1.1"
     repository: file://./charts/search
+    condition: global.enterprise
   - name: search-projector
     version: "^0.1.1"
     repository: file://./charts/search-projector
+    condition: global.enterprise
   - name: user-preferences
     version: "^0.1.0"
     repository: file://./charts/user-preferences


### PR DESCRIPTION
The condition ensures that the sub-charts are only installed when an Enterprise installation occurs.