### PR TITLE
fix: remove hardcoded backup path

### DIFF
--- a/charts/telicent-core/charts/admin-ui/templates/configmap-envjs.yaml
+++ b/charts/telicent-core/charts/admin-ui/templates/configmap-envjs.yaml
@@ -64,11 +64,11 @@ data:
 
     window._env_.BACKUP_APIS = {
         "smart-cache-graph": {
-            url: "https://api.system-integration.telicent-sandbox.telicent.live/graphql/$/backups",
+            url: "https://{{ .Values.global.apiHostDomain }}/graphql/$/backups",
             type: "SCG_LIST",
         },
         "smart-cache-search": {
-            url: "https://api.system-integration.telicent-sandbox.telicent.live/search/backups",
+            url: "https://{{ .Values.global.apiHostDomain }}/search/backups",
             type: "SNAPSHOT_LIST",
             metadata: {
                 repository: "scs-snapshots-repo", // The adapter will grab this


### PR DESCRIPTION
The path for the backup API's had been hardcoded to the SI cluster. Now updated to use the provided API host domain.

FYI @EmilyJKohler, @davec504.