### PR TITLE
[CORE-642] - Add backup details operation to the authorization policy for SC-Graph.

### DIFF
--- a/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
+++ b/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
@@ -39,6 +39,7 @@ spec:
         - /$/backups/create
         - /$/backups/create/*
         - /$/backups/restore/*
+        - /$/backups/details/*
         - /$/backups/delete/*
         - /$/backups/validate/*
         - /$/backups/report/*


### PR DESCRIPTION
Adds a missing operation for $/backups/details/<backup> from [CORE-642](https://github.com/telicent-oss/smart-cache-graph/pull/267).

[CORE-642]: https://telicent.atlassian.net/browse/CORE-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ