### PR TITLE
fix(apicurio): Add management port and correct URIs

### DIFF
--- a/charts/telicent-preview/charts/apicurio/templates/deployment.yaml
+++ b/charts/telicent-preview/charts/apicurio/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
 
         readinessProbe:
           httpGet:
-            path: /q/health/ready
+            path: /health/ready
             port: 9000
             scheme: HTTP
           initialDelaySeconds: 30
@@ -112,7 +112,7 @@ spec:
           timeoutSeconds: 5
         livenessProbe:
           httpGet:
-            path: /q/health/live
+            path: /health/live
             port: 9000
             scheme: HTTP
           initialDelaySeconds: 30

--- a/charts/telicent-preview/charts/apicurio/templates/service.yaml
+++ b/charts/telicent-preview/charts/apicurio/templates/service.yaml
@@ -21,3 +21,8 @@ spec:
     protocol: TCP
     targetPort: http
     port: {{ .Values.service.port }}
+  - name: management
+    appProtocol: http
+    protocol: TCP
+    targetPort: management
+    port: 9000


### PR DESCRIPTION
Health and readiness probes not correctly configured causing service to be repeatedly restarted.