### PR TITLE
[CORE-812] - Add /$/backups/restore operation to the graph authorization policy.

### DIFF
--- a/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
+++ b/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
@@ -39,6 +39,7 @@ spec:
         - /$/backups/create
         - /$/backups/create/*
         - /$/backups/restore/*
+        - /$/backups/restore
         - /$/backups/details/*
         - /$/backups/delete/*
         - /$/backups/validate/*


### PR DESCRIPTION
Enables [core-812](https://github.com/telicent-oss/smart-cache-graph/pull/240) - backup restore without arguments.