### PR TITLE
fix(auth): enable client secret from env vars

### DIFF
--- a/charts/telicent-core/charts/auth/README.md
+++ b/charts/telicent-core/charts/auth/README.md
@@ -175,13 +175,17 @@ For Quick Start purposes, a secret named `tc-auth-usr-psql-auth` will be created
 
 Contains configuration to be used to bootstrap a clean instance of the Auth application to a working state.
 
-| Name                                  | Description                                                                                                                                                                           | Value |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `bootstrap.clients.existingConfigMap` | Name of an existing config map resource containing all required public and confidential clients. If specified, the values for clients.public and clients.confidential will be ignored | `""`  |
-| `bootstrap.clients.public`            | A list of public client objects                                                                                                                                                       | `[]`  |
-| `bootstrap.clients.confidential`      | A list of confidential client objects                                                                                                                                                 | `[]`  |
-| `bootstrap.groups.existingConfigMap`  | Name of an existing config map containing a list of group objects                                                                                                                     | `""`  |
-| `bootstrap.groups.list`               | A list containing group objects                                                                                                                                                       | `[]`  |
+| Name                                             | Description                                                                                                                                                                           | Value |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `bootstrap.clients.existingConfigMap`            | Name of an existing config map resource containing all required public and confidential clients. If specified, the values for clients.public and clients.confidential will be ignored | `""`  |
+| `bootstrap.clients.public`                       | A list of public client objects                                                                                                                                                       | `[]`  |
+| `bootstrap.clients.confidential`                 | A list of confidential client objects                                                                                                                                                 | `[]`  |
+| `bootstrap.clients.notifications.existingSecret` | Name of an existing secret containing the notifications client secret. The secret must contain 1 key: 'client_secret'                                                                 | `""`  |
+| `bootstrap.clients.notifications.clientSecret`   | The notifications API client secret (NOTIFICATIONS_CLIENT_SECRET)                                                                                                                     | `""`  |
+| `bootstrap.clients.registry.existingSecret`      | Name of an existing secret containing the registry client secret. The secret must contain 1 key: 'client_secret'                                                                      | `""`  |
+| `bootstrap.clients.registry.clientSecret`        | The registry API client secret (REGISTRY_CLIENT_SECRET)                                                                                                                               | `""`  |
+| `bootstrap.groups.existingConfigMap`             | Name of an existing config map containing a list of group objects                                                                                                                     | `""`  |
+| `bootstrap.groups.list`                          | A list containing group objects                                                                                                                                                       | `[]`  |
 
 ### ConfigMap Parameters
 

--- a/charts/telicent-core/charts/auth/templates/_secrets.tpl
+++ b/charts/telicent-core/charts/auth/templates/_secrets.tpl
@@ -34,3 +34,25 @@ Create the name of the ForwardAuth secret
 {{- printf "tc-auth-gen-%s-%s" "forward" .Chart.Name }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Create the name of the notifications client secret
+*/}}
+{{- define "auth.notificationsClientSecretName" -}}
+{{- if .Values.bootstrap.clients.notifications.existingSecret }}
+{{- .Values.bootstrap.clients.notifications.existingSecret }}
+{{- else }}
+{{- printf "tc-auth-gen-notifications-api" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create the name of the registry client secret
+*/}}
+{{- define "auth.registryClientSecretName" -}}
+{{- if .Values.bootstrap.clients.registry.existingSecret }}
+{{- .Values.bootstrap.clients.registry.existingSecret }}
+{{- else }}
+{{- printf "tc-auth-gen-apicurio-registry-api" }}
+{{- end }}
+{{- end -}}

--- a/charts/telicent-core/charts/auth/templates/deployment.yaml
+++ b/charts/telicent-core/charts/auth/templates/deployment.yaml
@@ -95,7 +95,11 @@ spec:
 
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}
+          {{- if .valueFrom }}
+          valueFrom: {{- toYaml .valueFrom | nindent 12 }}
+          {{- else }}
           value: {{ .value | quote }}
+          {{- end }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/charts/telicent-core/charts/auth/templates/deployment.yaml
+++ b/charts/telicent-core/charts/auth/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         checksum/secretPsql: {{ include (print $.Template.BasePath "/secret-postgres.yaml") . | sha256sum }}
         checksum/configClients: {{ include (print $.Template.BasePath "/configmap-clients.yaml") . | sha256sum }}
         checksum/configGroups: {{ include (print $.Template.BasePath "/configmap-groups.yaml") . | sha256sum }}
+        checksum/secretNotificationsClient: {{ include (print $.Template.BasePath "/secret-notifications-client.yaml") . | sha256sum }}
+        checksum/secretRegistryClient: {{ include (print $.Template.BasePath "/secret-registry-client.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -92,6 +94,16 @@ spec:
             secretKeyRef:
               key: header
               name: {{ include "auth.forwardAuthSecretName" . }}
+        - name: NOTIFICATIONS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: client_secret
+              name: {{ include "auth.notificationsClientSecretName" . }}
+        - name: REGISTRY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: client_secret
+              name: {{ include "auth.registryClientSecretName" . }}
 
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}

--- a/charts/telicent-core/charts/auth/templates/secret-notifications-client.yaml
+++ b/charts/telicent-core/charts/auth/templates/secret-notifications-client.yaml
@@ -1,0 +1,17 @@
+{{- /*
+Copyright (C) 2026 Telicent Limited
+*/}}
+{{- if not .Values.bootstrap.clients.notifications.existingSecret }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: {{ include "auth.notificationsClientSecretName" . }}
+  namespace: {{ include "auth.namespace" . | quote }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+
+data:
+  client_secret: {{ .Values.bootstrap.clients.notifications.clientSecret | b64enc | quote }}
+{{- end }}

--- a/charts/telicent-core/charts/auth/templates/secret-notifications-client.yaml
+++ b/charts/telicent-core/charts/auth/templates/secret-notifications-client.yaml
@@ -2,16 +2,24 @@
 Copyright (C) 2026 Telicent Limited
 */}}
 {{- if not .Values.bootstrap.clients.notifications.existingSecret }}
+{{- $secretName := include "auth.notificationsClientSecretName" . }}
+{{- $existingSecret := lookup "v1" "Secret" (include "auth.namespace" .) $secretName }}
+{{- $clientSecret := .Values.bootstrap.clients.notifications.clientSecret }}
+{{- if and (not $clientSecret) $existingSecret }}
+{{- $clientSecret = index $existingSecret.data "client_secret" | b64dec }}
+{{- else if not $clientSecret }}
+{{- $clientSecret = randAlphaNum 32 }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 
 metadata:
-  name: {{ include "auth.notificationsClientSecretName" . }}
+  name: {{ $secretName }}
   namespace: {{ include "auth.namespace" . | quote }}
   labels:
     {{- include "auth.labels" . | nindent 4 }}
 
 data:
-  client_secret: {{ .Values.bootstrap.clients.notifications.clientSecret | b64enc | quote }}
+  client_secret: {{ $clientSecret | b64enc | quote }}
 {{- end }}

--- a/charts/telicent-core/charts/auth/templates/secret-registry-client.yaml
+++ b/charts/telicent-core/charts/auth/templates/secret-registry-client.yaml
@@ -2,16 +2,24 @@
 Copyright (C) 2026 Telicent Limited
 */}}
 {{- if not .Values.bootstrap.clients.registry.existingSecret }}
+{{- $secretName := include "auth.registryClientSecretName" . }}
+{{- $existingSecret := lookup "v1" "Secret" (include "auth.namespace" .) $secretName }}
+{{- $clientSecret := .Values.bootstrap.clients.registry.clientSecret }}
+{{- if and (not $clientSecret) $existingSecret }}
+{{- $clientSecret = index $existingSecret.data "client_secret" | b64dec }}
+{{- else if not $clientSecret }}
+{{- $clientSecret = randAlphaNum 32 }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 
 metadata:
-  name: {{ include "auth.registryClientSecretName" . }}
+  name: {{ $secretName }}
   namespace: {{ include "auth.namespace" . | quote }}
   labels:
     {{- include "auth.labels" . | nindent 4 }}
 
 data:
-  client_secret: {{ .Values.bootstrap.clients.registry.clientSecret | b64enc | quote }}
+  client_secret: {{ $clientSecret | b64enc | quote }}
 {{- end }}

--- a/charts/telicent-core/charts/auth/templates/secret-registry-client.yaml
+++ b/charts/telicent-core/charts/auth/templates/secret-registry-client.yaml
@@ -1,0 +1,17 @@
+{{- /*
+Copyright (C) 2026 Telicent Limited
+*/}}
+{{- if not .Values.bootstrap.clients.registry.existingSecret }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: {{ include "auth.registryClientSecretName" . }}
+  namespace: {{ include "auth.namespace" . | quote }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+
+data:
+  client_secret: {{ .Values.bootstrap.clients.registry.clientSecret | b64enc | quote }}
+{{- end }}

--- a/charts/telicent-core/charts/auth/values.schema.json
+++ b/charts/telicent-core/charts/auth/values.schema.json
@@ -305,6 +305,36 @@
                             "description": "A list of confidential client objects",
                             "default": [],
                             "items": {}
+                        },
+                        "notifications": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of an existing secret containing the notifications client secret. The secret must contain 1 key: 'client_secret'",
+                                    "default": ""
+                                },
+                                "clientSecret": {
+                                    "type": "string",
+                                    "description": "The notifications API client secret (NOTIFICATIONS_CLIENT_SECRET)",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "registry": {
+                            "type": "object",
+                            "properties": {
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of an existing secret containing the registry client secret. The secret must contain 1 key: 'client_secret'",
+                                    "default": ""
+                                },
+                                "clientSecret": {
+                                    "type": "string",
+                                    "description": "The registry API client secret (REGISTRY_CLIENT_SECRET)",
+                                    "default": ""
+                                }
+                            }
                         }
                     }
                 },

--- a/charts/telicent-core/charts/auth/values.yaml
+++ b/charts/telicent-core/charts/auth/values.yaml
@@ -192,6 +192,14 @@ bootstrap:
     #   client_secret: password-1
     #   client_authentication_method: client_secret_post
     #   scope: write
+    # To avoid embedding a secret in values, use client_secret_env_var_name instead of client_secret.
+    # The application will read the secret from the named environment variable at runtime.
+    # Supply the variable via extraEnvVars using a secretKeyRef (see extraEnvVars below).
+    # - client_id: client-1
+    #   client_name: 'Secret Client'
+    #   client_secret_env_var_name: CLIENT_1_SECRET
+    #   client_authentication_method: client_secret_post
+    #   scope: write
 
   groups:
     # @key bootstrap.groups.existingConfigMap Name of an existing config map containing a list of group objects
@@ -243,10 +251,17 @@ podLabels: {}
 # @key podAnnotations Add extra annotations to the *Auth* pod
 podAnnotations: {}
 # @key extraEnvVars Array with extra environment variables to add to *Auth* pod
+# Supports both plain values and valueFrom (e.g. secretKeyRef) for injecting secret values.
+# Use valueFrom.secretKeyRef to supply a confidential client secret referenced by client_secret_env_var_name.
 # Example:
 # extraEnvVars:
 # - name: FOO
 #   value: instance
+# - name: CLIENT_1_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-k8s-secret
+#       key: client_secret
 extraEnvVars: []
 # @key extraVolumes Optionally specify extra list of additional volumes
 extraVolumes: []

--- a/charts/telicent-core/charts/auth/values.yaml
+++ b/charts/telicent-core/charts/auth/values.yaml
@@ -201,6 +201,20 @@ bootstrap:
     #   client_authentication_method: client_secret_post
     #   scope: write
 
+    notifications:
+      # @key bootstrap.clients.notifications.existingSecret Name of an existing secret containing the notifications client secret. The secret must contain 1 key: 'client_secret'
+      # Note: Left unset, it will create a secret named: tc-auth-gen-notifications-api
+      existingSecret: ""
+      # @key bootstrap.clients.notifications.clientSecret The notifications API client secret (NOTIFICATIONS_CLIENT_SECRET)
+      clientSecret: ""
+
+    registry:
+      # @key bootstrap.clients.registry.existingSecret Name of an existing secret containing the registry client secret. The secret must contain 1 key: 'client_secret'
+      # Note: Left unset, it will create a secret named: tc-auth-gen-apicurio-registry-api
+      existingSecret: ""
+      # @key bootstrap.clients.registry.clientSecret The registry API client secret (REGISTRY_CLIENT_SECRET)
+      clientSecret: ""
+
   groups:
     # @key bootstrap.groups.existingConfigMap Name of an existing config map containing a list of group objects
     existingConfigMap: ""

--- a/charts/telicent-preview/charts/apicurio/templates/deployment.yaml
+++ b/charts/telicent-preview/charts/apicurio/templates/deployment.yaml
@@ -91,7 +91,11 @@ spec:
         {{- end }}
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}
+          {{- if .value }}
           value: {{ .value | quote }}
+          {{- else if .valueFrom }}
+          valueFrom: {{- toYaml .valueFrom | nindent 12 }}
+          {{- end }}
         {{- end }}
 
         ports:

--- a/charts/telicent-preview/charts/apicurio/values.yaml
+++ b/charts/telicent-preview/charts/apicurio/values.yaml
@@ -54,10 +54,16 @@ podLabels: {}
 # @key podAnnotations Add extra annotations to the *Apicurio* pod
 podAnnotations: {}
 # @key extraEnvVars Array with extra environment variables to add to *Apicurio* pod
+# Supports both plain values and valueFrom (e.g. secretKeyRef) for injecting secret values.
 # Example:
 # extraEnvVars:
 # - name: FOO
 #   value: instance
+# - name: CLIENT_1_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-k8s-secret
+#       key: client_secret
 extraEnvVars: []
 # @key extraVolumes Optionally specify extra list of additional volumes
 extraVolumes: []

--- a/charts/telicent-preview/charts/notifications-projector/README.md
+++ b/charts/telicent-preview/charts/notifications-projector/README.md
@@ -226,6 +226,16 @@ Contains configuration parameters specific to the *Notifications Projector* appl
 | `metrics.service.name` | Name for the Prometheus service | `metrics` |
 | `metrics.service.port` | Port for the Prometheus service | `9464`    |
 
+### Host(s) Core Parameters - Contains host information for applications deployed via *telicent-core* chart
+
+*Notifications Projector* interacts with applications deployed via *telicent-core* using their default service/serviceAccount and port.
+If either of those details changes, you can use this section to correctly refer to those applications.
+
+| Name                          | Description                                                                                                                                     | Value       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `hostsCore.enableAutoCorrect` | Prefix 'global.releaseNameTelicentCore' value to each host value. Alternatively, the host value will be used as it is, without any modification | `true`      |
+| `hostsCore.auth`              | Auth application default host value, as defined by 'service/serviceAccount:port'                                                                | `auth:8080` |
+
 ## License
 
 Copyright &copy; 2026 Telicent Limited

--- a/charts/telicent-preview/charts/notifications-projector/templates/_hosts.tpl
+++ b/charts/telicent-preview/charts/notifications-projector/templates/_hosts.tpl
@@ -1,0 +1,13 @@
+{{/*
+Copyright (C) 2026 Telicent Limited
+*/}}
+
+{{/*
+This file contains the names of other host/service name(s) and service account name(s) on which this
+application relies on. For a full explanation please view '_hosts.tlp' file in the 'auth' sub-chart.
+*/}}
+
+{{/* auth | core - returns host ('service:port') and serviceAccount */}}
+{{- define "notifications-projector.hostAuth" -}}
+{{- printf "%s" (include "common.discoverHostCore" (list . .Values.hostsCore.auth )) -}}
+{{- end -}}

--- a/charts/telicent-preview/charts/notifications-projector/templates/configmap-env.yaml
+++ b/charts/telicent-preview/charts/notifications-projector/templates/configmap-env.yaml
@@ -23,6 +23,8 @@ data:
   ENABLE_VALIDATION: {{ .Values.validation.enabled | quote }}
   REGISTRY_HOSTNAME: {{ .Values.validation.registry.hostname | quote }}
   REGISTRY_PORT: {{ .Values.validation.registry.port | quote }}
+  AUTH_TOKEN_ENDPOINT: {{ printf "http://%s%s" (include "notifications-projector.hostAuth" .) "/oauth2/token" | quote }}
+  FORWARD_AUTH_ENDPOINT: {{ printf "http://%s%s" (include "notifications-projector.hostAuth" .) "/auth/forward" | quote }}
   {{- end }}
 
   {{- if .Values.metrics.enabled }}

--- a/charts/telicent-preview/charts/notifications-projector/values.schema.json
+++ b/charts/telicent-preview/charts/notifications-projector/values.schema.json
@@ -429,6 +429,21 @@
                     }
                 }
             }
+        },
+        "hostsCore": {
+            "type": "object",
+            "properties": {
+                "enableAutoCorrect": {
+                    "type": "boolean",
+                    "description": "Prefix 'global.releaseNameTelicentCore' value to each host value. Alternatively, the host value will be used as it is, without any modification",
+                    "default": true
+                },
+                "auth": {
+                    "type": "string",
+                    "description": "Auth application default host value, as defined by 'service/serviceAccount:port'",
+                    "default": "auth:8080"
+                }
+            }
         }
     }
 }

--- a/charts/telicent-preview/charts/notifications-projector/values.yaml
+++ b/charts/telicent-preview/charts/notifications-projector/values.yaml
@@ -125,10 +125,17 @@ podLabels: {}
 # @key podAnnotations Add extra annotations to the *Notifications Projector* pod
 podAnnotations: {}
 # @key extraEnvVars Array with extra environment variables to add to *Notifications Projector* pod
+# Supports both plain values and valueFrom (e.g. secretKeyRef) for injecting secret values.
+# Use valueFrom.secretKeyRef to supply a confidential client secret referenced by client_secret_env_var_name.
 # Example:
 # extraEnvVars:
 # - name: FOO
 #   value: instance
+# - name: CLIENT_1_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-k8s-secret
+#       key: client_secret
 extraEnvVars: []
 # @key extraVolumes Optionally specify extra list of additional volumes
 extraVolumes: []
@@ -255,3 +262,16 @@ metrics:
     name: metrics
     # @key metrics.service.port Port for the Prometheus service
     port: 9464
+
+#
+# @section Host(s) Core Parameters - Contains host information for applications deployed via *telicent-core* chart
+#
+# @descStart
+# *Notifications Projector* interacts with applications deployed via *telicent-core* using their default service/serviceAccount and port.
+# If either of those details changes, you can use this section to correctly refer to those applications.
+# @descEnd
+hostsCore:
+  # @key hostsCore.enableAutoCorrect Prefix 'global.releaseNameTelicentCore' value to each host value. Alternatively, the host value will be used as it is, without any modification
+  enableAutoCorrect: true
+  # @key hostsCore.auth Auth application default host value, as defined by 'service/serviceAccount:port'
+  auth: "auth:8080"

--- a/charts/telicent-preview/charts/notifications/templates/configmap-env.yaml
+++ b/charts/telicent-preview/charts/notifications/templates/configmap-env.yaml
@@ -22,12 +22,14 @@ data:
   DATABASE_JDBC_URL: {{ .Values.postgres.jdbcUrl | quote }}
 
   JWKS_URL: {{ printf "https://%s%s" .Values.global.authHostDomain "/oauth2/jwks" | quote }}
-  USERINFO_URL: {{ printf "http://%s%s" (include "notifications.hostAuth" . ) "/userinfo" | quote }}
+  USERINFO_URL: {{ printf "https://%s%s" .Values.global.authHostDomain "/userinfo" | quote }}
 
   {{- if .Values.validation.enabled }}
   ENABLE_VALIDATION: {{ .Values.validation.enabled | quote }}
   REGISTRY_HOSTNAME: {{ .Values.validation.registry.hostname | quote }}
   REGISTRY_PORT: {{ .Values.validation.registry.port | quote }}
+  AUTH_TOKEN_ENDPOINT: {{ printf "http://%s%s" (include "notifications.hostAuth" .) "/oauth2/token" | quote }}
+  FORWARD_AUTH_ENDPOINT: {{ printf "http://%s%s" (include "notifications.hostAuth" .) "/auth/forward" | quote }}
   {{- end }}
 
   {{- if .Values.metrics.enabled }}

--- a/charts/telicent-preview/charts/notifications/templates/deployment.yaml
+++ b/charts/telicent-preview/charts/notifications/templates/deployment.yaml
@@ -75,7 +75,12 @@ spec:
 
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}
+          {{- if .valueFrom }}
+          valueFrom:
+            {{- toYaml .valueFrom | nindent 12 }}
+          {{- else }}
           value: {{ .value | quote }}
+          {{- end }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/charts/telicent-preview/charts/notifications/values.yaml
+++ b/charts/telicent-preview/charts/notifications/values.yaml
@@ -137,10 +137,17 @@ podLabels: {}
 # @key podAnnotations Add extra annotations to the *Notifications* pod
 podAnnotations: {}
 # @key extraEnvVars Array with extra environment variables to add to *Notifications* pod
+# Supports both plain values and valueFrom (e.g. secretKeyRef) for injecting secret values.
+# Use valueFrom.secretKeyRef to supply a confidential client secret referenced by client_secret_env_var_name.
 # Example:
 # extraEnvVars:
 # - name: FOO
 #   value: instance
+# - name: CLIENT_1_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-k8s-secret
+#       key: client_secret
 extraEnvVars: []
 # @key extraVolumes Optionally specify extra list of additional volumes
 extraVolumes: []


### PR DESCRIPTION
This PR address the issue of the seeded confidential clients in Auth Server not being able to access their client secret by enabling the secret to go into an environment variable (one for each client). Auth Server has been updated to accommodate this change (see https://github.com/Telicent-io/auth-server/pull/279). 