### PR TITLE
feat(graph): Add SHACL validation endpoints

### DIFF
--- a/charts/telicent-core/charts/graph/templates/_fuseki.tpl
+++ b/charts/telicent-core/charts/graph/templates/_fuseki.tpl
@@ -71,6 +71,11 @@ Copyright (C) 2026 Telicent Limited
             fuseki:operation fuseki:gsp-r ;
             fuseki:name "get"
         ] ;
+        fuseki:endpoint [
+            # SHACL validation on "/knowledge/shacl"
+            fuseki:operation fuseki:shacl ;
+            fuseki:name "shacl"
+        ] ;
         # Knowledge dataset to use
         fuseki:dataset :datasetAuth ;
         .
@@ -133,6 +138,11 @@ Copyright (C) 2026 Telicent Limited
             fuseki:operation fuseki:gsp-r ;
             fuseki:name "get"
         ] ;
+        fuseki:endpoint [
+            # SHACL validation on "/ontology/shacl"
+            fuseki:operation fuseki:shacl ;
+            fuseki:name "shacl"
+        ] ;
         # Ontology dataset to use
         fuseki:dataset :ontologyDataset ;
         .
@@ -194,6 +204,11 @@ Copyright (C) 2026 Telicent Limited
             # SPARQL Graph Store Protocol (read) on "/catalog/get"
             fuseki:operation fuseki:gsp-r ;
             fuseki:name "get"
+        ] ;
+        fuseki:endpoint [
+            # SHACL validation on "/catalog/shacl"
+            fuseki:operation fuseki:shacl ;
+            fuseki:name "shacl"
         ] ;
         # Catalog dataset to use
         fuseki:dataset :catalogDataset ;

--- a/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
+++ b/charts/telicent-core/charts/graph/templates/istio/authorizationpolicy.yaml
@@ -61,4 +61,8 @@ spec:
         - /knowledge/graphql/*
         - /knowledge/shacl
         - /knowledge/shacl/*
+        - /ontology/shacl
+        - /ontology/shacl/*
+        - /catalog/shacl
+        - /catalog/shacl/*
         methods: ["POST"]

--- a/charts/telicent-core/charts/traefik-proxy/configs/routes/api/graph.yaml
+++ b/charts/telicent-core/charts/traefik-proxy/configs/routes/api/graph.yaml
@@ -17,6 +17,14 @@ http:
       middleWares:
         - path-graph-graphql
         - host-graph
+    graph-shacl:
+      rule: {{ printf "Host(`%s`) && PathPrefix(`/shacl`)" .Values.global.apiHostDomain }}
+      service: graph
+      entryPoints:
+        - web-api
+      middleWares:
+        - path-graph-shacl
+        - host-graph
   services:
     graph:
       loadBalancer:
@@ -31,6 +39,10 @@ http:
     path-graph-graphql:
       replacePathRegex:
         regex: "^/graphql/(.*)"
+        replacement: "/$1"
+    path-graph-shacl:
+      replacePathRegex:
+        regex: "^/shacl/(.*)"
         replacement: "/$1"
     host-graph:
       headers:


### PR DESCRIPTION
This PR adds SHACL validation endpoints to the Fuseki config and enables access via Traefik proxy. This follows the work done in RDF ABAC (https://github.com/telicent-oss/rdf-abac/pull/207) to enable ABAC filtering of datasets prior to validation.