### PR TITLE
fix(graph): Disable legacy labels store by default (CORE-1149)

### DIFF
--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     repository: file://./charts/document-pipeline
     condition: global.enterprise
   - name: graph
-    version: "^0.1.0"
+    version: "^0.2.2"
     repository: file://./charts/graph
   - name: graph-ui
     version: "1.37.3"

--- a/charts/telicent-core/charts/graph/Chart.yaml
+++ b/charts/telicent-core/charts/graph/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/telicent-core/charts/graph/README.md
+++ b/charts/telicent-core/charts/graph/README.md
@@ -119,7 +119,7 @@ Contains configuration parameters that configure aspects of the *Graph* applicat
 | Name                       | Description                                                                                                                                                                                                                                                                                      | Value   |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
 | `graph.routeToNamedGraphs` | Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.                                                                                                                         | `false` |
-| `graph.legacyLabels`       | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `true`  |
+| `graph.legacyLabels`       | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `false` |
 
 ### ConfigMap Parameters
 

--- a/charts/telicent-core/charts/graph/values.schema.json
+++ b/charts/telicent-core/charts/graph/values.schema.json
@@ -114,7 +114,7 @@
                 "legacyLabels": {
                     "type": "boolean",
                     "description": "Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format.",
-                    "default": true
+                    "default": false
                 }
             }
         },

--- a/charts/telicent-core/charts/graph/values.yaml
+++ b/charts/telicent-core/charts/graph/values.yaml
@@ -74,7 +74,7 @@ graph:
   # @key graph.routeToNamedGraphs Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.
   routeToNamedGraphs: false
   # @key graph.legacyLabels Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format.
-  legacyLabels: true
+  legacyLabels: false
 
 #
 # @section ConfigMap Parameters


### PR DESCRIPTION
After testing in SI we're happy that the new labels store functions as intended and has no hierthero undiscovered bugs.  Given its improved storage and performance we are now making this the default