### PR TITLE
fix(search): Re-enable labels index configuration (CORE-1120)

### DIFF
--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -52,11 +52,11 @@ dependencies:
     version: "1.5.4"
     repository: oci://quay.io/telicent/charts/query-ui
   - name: search
-    version: "^0.2.0"
+    version: "^0.2.2"
     repository: file://./charts/search
     condition: global.enterprise
   - name: search-projector
-    version: "^0.2.0"
+    version: "^0.2.2"
     repository: file://./charts/search-projector
     condition: global.enterprise
   - name: search-ui

--- a/charts/telicent-core/charts/search-projector/Chart.yaml
+++ b/charts/telicent-core/charts/search-projector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/telicent-core/charts/search-projector/README.md
+++ b/charts/telicent-core/charts/search-projector/README.md
@@ -113,21 +113,21 @@ The following contains connection details to an Elastic/OpenSearch service, on w
 It is recommended to store sensitive information including passwords in a Kubernetes secret and not in Helm values.
 For Quick Start purposes, a secret named `tc-auth-usr-elastic-search-projector` will be created if one is not set.
 
-| Name                              | Description                                                                                                             | Value                          |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `elastic.host`                    | Elastic/OpenSearch host                                                                                                 | `https://your.opensearch.host` |
-| `elastic.port`                    | Elastic/OpenSearch cluster port                                                                                         | `443`                          |
-| `elastic.opensearchCompatibility` | Enable OpenSearch compatibility                                                                                         | `true`                         |
-| `elastic.index`                   | Elastic/OpenSearch index to be used                                                                                     | `search`                       |
-| `elastic.labelsIndex`             | Elastic/OpenSearch index to store security labels.  Not currently usable due to API compatibility issues with RDF-ABAC. | `""`                           |
-| `elastic.topic`                   | Topic to consume messages from                                                                                          | `knowledge`                    |
-| `elastic.dlqTopic`                | Dead-letter topic for failed messages                                                                                   | `knowledge.dlq`                |
-| `elastic.actionsTopic`            | Topic used to synchronise actions between the *Search Projector* and the *Search API* applications.                     | `actions`                      |
-| `elastic.indexBatchSize`          | Number of documents to index in a single batch operation                                                                | `500`                          |
-| `elastic.entityProjection`        | Name of the entity projection to be used, leave blank for default which is suitable for most use cases.                 | `""`                           |
-| `elastic.existingSecret`          | Name of an existing secret. The secret must contain 2 keys: 'username', 'password'                                      | `""`                           |
-| `elastic.username`                | OpenSearch/Elastic username                                                                                             | `""`                           |
-| `elastic.password`                | OpenSearch/Elastic user password                                                                                        | `""`                           |
+| Name                              | Description                                                                                             | Value                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `elastic.host`                    | Elastic/OpenSearch host                                                                                 | `https://your.opensearch.host` |
+| `elastic.port`                    | Elastic/OpenSearch cluster port                                                                         | `443`                          |
+| `elastic.opensearchCompatibility` | Enable OpenSearch compatibility                                                                         | `true`                         |
+| `elastic.index`                   | Elastic/OpenSearch index to be used                                                                     | `search`                       |
+| `elastic.labelsIndex`             | Elastic/OpenSearch index to store security labels.                                                      | `""`                           |
+| `elastic.topic`                   | Topic to consume messages from                                                                          | `knowledge`                    |
+| `elastic.dlqTopic`                | Dead-letter topic for failed messages                                                                   | `knowledge.dlq`                |
+| `elastic.actionsTopic`            | Topic used to synchronise actions between the *Search Projector* and the *Search API* applications.     | `actions`                      |
+| `elastic.indexBatchSize`          | Number of documents to index in a single batch operation                                                | `500`                          |
+| `elastic.entityProjection`        | Name of the entity projection to be used, leave blank for default which is suitable for most use cases. | `""`                           |
+| `elastic.existingSecret`          | Name of an existing secret. The secret must contain 2 keys: 'username', 'password'                      | `""`                           |
+| `elastic.username`                | OpenSearch/Elastic username                                                                             | `""`                           |
+| `elastic.password`                | OpenSearch/Elastic user password                                                                        | `""`                           |
 
 ### ConfigMap Parameters
 

--- a/charts/telicent-core/charts/search-projector/templates/configmap-env.yaml
+++ b/charts/telicent-core/charts/search-projector/templates/configmap-env.yaml
@@ -17,9 +17,7 @@ data:
   ELASTIC_PORT: {{ .Values.elastic.port | quote }}
   OPENSEARCH_COMPATIBILITY: {{ .Values.elastic.opensearchCompatibility | quote }}
   ELASTIC_INDEX: {{ .Values.elastic.index | quote }}
-
-  # CORE-1123 - Not currently usable due to API compatibility issues with RDF-ABAC
-  #ELASTIC_LABELS_INDEX: {{ .Values.elastic.labelsIndex | quote }}
+  ELASTIC_LABELS_INDEX: {{ .Values.elastic.labelsIndex | quote }}
 
   # Projector Configuration
   INDEX_BATCH_SIZE: {{ .Values.elastic.indexBatchSize | quote }}

--- a/charts/telicent-core/charts/search-projector/values.schema.json
+++ b/charts/telicent-core/charts/search-projector/values.schema.json
@@ -103,7 +103,7 @@
                 },
                 "labelsIndex": {
                     "type": "string",
-                    "description": "Elastic/OpenSearch index to store security labels.  Not currently usable due to API compatibility issues with RDF-ABAC.",
+                    "description": "Elastic/OpenSearch index to store security labels.",
                     "default": ""
                 },
                 "topic": {

--- a/charts/telicent-core/charts/search-projector/values.yaml
+++ b/charts/telicent-core/charts/search-projector/values.yaml
@@ -67,7 +67,7 @@ elastic:
   opensearchCompatibility: true
   # @key elastic.index Elastic/OpenSearch index to be used
   index: search
-  # @key elastic.labelsIndex Elastic/OpenSearch index to store security labels.  Not currently usable due to API compatibility issues with RDF-ABAC.
+  # @key elastic.labelsIndex Elastic/OpenSearch index to store security labels.
   labelsIndex: ""
   # @key elastic.topic Topic to consume messages from
   topic: knowledge

--- a/charts/telicent-core/charts/search/Chart.yaml
+++ b/charts/telicent-core/charts/search/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/telicent-core/charts/search/README.md
+++ b/charts/telicent-core/charts/search/README.md
@@ -123,6 +123,7 @@ For Quick Start purposes, a secret named `tc-auth-usr-elastic-search` will be cr
 | `elastic.port`                    | Elastic/OpenSearch port number                                                                      | `443`                          |
 | `elastic.opensearchCompatibility` | Enable OpenSearch compatibility                                                                     | `true`                         |
 | `elastic.index`                   | Elastic/OpenSearch index to be used                                                                 | `search,doc-content`           |
+| `elastic.labelsIndex`             | Elastic/OpenSearch index to store security labels.                                                  | `""`                           |
 | `elastic.searchFieldOptions`      | Field options for search                                                                            | `primaryName^2,*`              |
 | `elastic.indexBatchSize`          | Number of documents to index in a single batch operation                                            | `100`                          |
 | `elastic.actionsTopic`            | Topic used to synchronise actions between the *Search Projector* and the *Search API* applications. | `actions`                      |

--- a/charts/telicent-core/charts/search/templates/configmap-env.yaml
+++ b/charts/telicent-core/charts/search/templates/configmap-env.yaml
@@ -19,6 +19,7 @@ data:
   ELASTIC_PORT: {{ .Values.elastic.port | quote }}
   OPENSEARCH_COMPATIBILITY: {{ .Values.elastic.opensearchCompatibility | quote }}
   ELASTIC_INDEX: {{ .Values.elastic.index | quote }}
+  ELASTIC_LABELS_INDEX: {{ .Values.elastic.labelsIndex | quote }}
 
   # Search API Configuration
   FIELD_OPTIONS: {{ .Values.elastic.searchFieldOptions | quote }}

--- a/charts/telicent-core/charts/search/values.schema.json
+++ b/charts/telicent-core/charts/search/values.schema.json
@@ -121,6 +121,11 @@
                     "description": "Elastic/OpenSearch index to be used",
                     "default": "search,doc-content"
                 },
+                "labelsIndex": {
+                    "type": "string",
+                    "description": "Elastic/OpenSearch index to store security labels.",
+                    "default": ""
+                },
                 "searchFieldOptions": {
                     "type": "string",
                     "description": "Field options for search",

--- a/charts/telicent-core/charts/search/values.yaml
+++ b/charts/telicent-core/charts/search/values.yaml
@@ -78,6 +78,8 @@ elastic:
   opensearchCompatibility: true
   # @key elastic.index Elastic/OpenSearch index to be used
   index: search,doc-content
+  # @key elastic.labelsIndex Elastic/OpenSearch index to store security labels.
+  labelsIndex: ""
   # @key elastic.searchFieldOptions Field options for search
   # This is a comma-separated list of fields to be used for search, with optional weights
   searchFieldOptions: "primaryName^2,*"


### PR DESCRIPTION
This PR is a follow up to PR #495, now that we've resolved RDF-ABAC compatibility issues we can now make the labels index feature properly available.  It remains off by default (blank default value for the new setting) for the time being to enable us to complete testing in SI