### PR TITLE
fix(search): Make Search informational APIs available (CORE-1255)

### DIFF
--- a/charts/telicent-core/charts/search/templates/istio/authorizationpolicy-internal.yaml
+++ b/charts/telicent-core/charts/search/templates/istio/authorizationpolicy-internal.yaml
@@ -36,6 +36,9 @@ spec:
         - /states/*
         - /typeahead
         - /typeahead/*
+        - /indices
+        - /aggregation-strategies
+        - /aggregation-strategies/*
         - /healthz
         - /healthz/*
         - /version-info

--- a/charts/telicent-core/charts/search/templates/istio/authorizationpolicy.yaml
+++ b/charts/telicent-core/charts/search/templates/istio/authorizationpolicy.yaml
@@ -36,6 +36,9 @@ spec:
         - /states/*
         - /typeahead
         - /typeahead/*
+        - /indices
+        - /aggregation-strategies
+        - /aggregation-strategies/*
         - /healthz
         - /healthz/*
         - /version-info


### PR DESCRIPTION
Some of the newer informational APIs in the Search REST API were not included in the Istio policy so could not be reached