### PR TITLE
chore: fix OCI repositories

### DIFF
--- a/charts/telicent-core/Chart.lock
+++ b/charts/telicent-core/Chart.lock
@@ -1,36 +1,36 @@
 dependencies:
 - name: admin-ui
-  repository: file://./charts/admin-ui
-  version: 0.1.10
+  repository: oci://quay.io/telicent/charts
+  version: 1.5.0
 - name: auth
   repository: file://./charts/auth
-  version: 0.1.7
-- name: graph-ui
-  repository: file://./charts/graph-ui
-  version: 0.1.12
-- name: query-ui
-  repository: file://./charts/query-ui
-  version: 0.1.8
-- name: search-ui
-  repository: file://./charts/search-ui
   version: 0.1.11
-- name: graph
-  repository: file://./charts/graph
-  version: 0.1.54
-- name: search
-  repository: file://./charts/search
-  version: 0.1.9
-- name: search-projector
-  repository: file://./charts/search-projector
-  version: 0.1.8
-- name: user-preferences
-  repository: file://./charts/user-preferences
-  version: 0.1.4
-- name: traefik-proxy
-  repository: file://./charts/traefik-proxy
-  version: 0.1.0
 - name: document-pipeline
   repository: file://./charts/document-pipeline
-  version: 0.1.2
-digest: sha256:46097f7390d5fbb53e9e99b7dd06fe239c526799e708407433b213cf3fb3e894
-generated: "2025-12-16T16:50:05.813937Z"
+  version: 0.1.5
+- name: graph
+  repository: file://./charts/graph
+  version: 0.2.2
+- name: graph-ui
+  repository: oci://quay.io/telicent/charts
+  version: 1.37.3
+- name: query-ui
+  repository: oci://quay.io/telicent/charts
+  version: 1.5.4
+- name: search
+  repository: file://./charts/search
+  version: 0.2.3
+- name: search-projector
+  repository: file://./charts/search-projector
+  version: 0.2.2
+- name: search-ui
+  repository: oci://quay.io/telicent/charts
+  version: 4.19.8
+- name: traefik-proxy
+  repository: file://./charts/traefik-proxy
+  version: 0.1.1
+- name: user-preferences
+  repository: file://./charts/user-preferences
+  version: 0.2.1
+digest: sha256:e4c27ff85c4f8dc79cbdd4273ea0ce06681fb67b2465076f9b43e762d629d765
+generated: "2026-05-28T11:15:50.579538+01:00"

--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -32,7 +32,7 @@ appVersion: "1.16.0"
 dependencies:
   - name: admin-ui
     version: "1.5.0"
-    repository: oci://quay.io/telicent/charts/admin-ui
+    repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: auth
     version: "^0.1.0"
@@ -46,11 +46,11 @@ dependencies:
     repository: file://./charts/graph
   - name: graph-ui
     version: "1.37.3"
-    repository: oci://quay.io/telicent/charts/graph-ui
+    repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: query-ui
     version: "1.5.4"
-    repository: oci://quay.io/telicent/charts/query-ui
+    repository: oci://quay.io/telicent/charts
   - name: search
     version: "^0.2.2"
     repository: file://./charts/search
@@ -61,7 +61,7 @@ dependencies:
     condition: global.enterprise
   - name: search-ui
     version: "4.19.8"
-    repository: oci://quay.io/telicent/charts/search-ui
+    repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: traefik-proxy
     version: "^0.1.0"

--- a/charts/telicent-preview/Chart.lock
+++ b/charts/telicent-preview/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: data-catalog-ui
-  repository: file://./charts/data-catalog-ui
-  version: 0.1.6
+  repository: oci://quay.io/telicent/charts
+  version: 1.15.3
 - name: notifications
   repository: file://./charts/notifications
   version: 0.1.0
@@ -12,10 +12,10 @@ dependencies:
   repository: file://./charts/paperback-writer
   version: 0.1.3
 - name: user-portal-ui
-  repository: file://./charts/user-portal-ui
-  version: 0.1.9
+  repository: oci://quay.io/telicent/charts
+  version: 1.9.0
 - name: apicurio
   repository: file://./charts/apicurio
   version: 0.1.0
-digest: sha256:fbc2f0950e260091aa9c905c7a563dd2a06d55a53d85ca8e8489bd6dff6b79e2
-generated: "2026-04-02T18:06:59.81216+01:00"
+digest: sha256:c76168a9df9d49ec33d1a060682ca4577c4d7eca10d35cc739e9b32b586e99b6
+generated: "2026-05-28T11:17:33.217667+01:00"

--- a/charts/telicent-preview/Chart.yaml
+++ b/charts/telicent-preview/Chart.yaml
@@ -28,7 +28,7 @@ appVersion: "1.16.0"
 dependencies:
   - name: data-catalog-ui
     version: "1.15.3"
-    repository: oci://quay.io/telicent/charts/data-catalog-ui
+    repository: oci://quay.io/telicent/charts
     condition: data-catalog-ui.enabled
   - name: notifications
     version: "^0.1.0"
@@ -44,7 +44,7 @@ dependencies:
     condition: global.enterprise, paperback-writer.enabled
   - name: user-portal-ui
     version: "1.9.0"
-    repository: oci://quay.io/telicent/charts/user-portal-ui
+    repository: oci://quay.io/telicent/charts
     condition: user-portal-ui.enabled
   - name: apicurio
     version: "^0.1.0"


### PR DESCRIPTION
When referencing a chart in a repo, the name of the chart isn't needed. Tested this on a demo cluster and it deploys.