### PR TITLE
Teldevops 1129/add ontology adapter chart

### DIFF
--- a/charts/telicent-data/Chart.lock
+++ b/charts/telicent-data/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: ies-regions-producer
   repository: oci://quay.io/telicent/charts
   version: 0.13.6
-digest: sha256:951011b8598eeeded8133f38cdb35c291283d097131f3512e3caf70143d6d8b4
-generated: "2026-07-06T15:09:52.868871+01:00"
+- name: telicent-ontology-adapter
+  repository: oci://quay.io/telicent/charts
+  version: 0.1.4
+digest: sha256:e56be3ae34abf83ed4309664a673ee163ad498212e429c1038aa827d26712f50
+generated: "2026-07-06T17:17:06.742448+01:00"

--- a/charts/telicent-data/Chart.yaml
+++ b/charts/telicent-data/Chart.yaml
@@ -59,3 +59,6 @@ dependencies:
   - name: ies-regions-producer
     version: 0.13.6
     repository: oci://quay.io/telicent/charts
+  - name: telicent-ontology-adapter
+    version: 0.1.4
+    repository: oci://quay.io/telicent/charts

--- a/charts/telicent-data/Chart.yaml
+++ b/charts/telicent-data/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Jira ticket: https://telicent.atlassian.net/browse/TELDEVOPS-1129

---

Added a Helm chart for `telicent-ontology-adapter`. The following screenshot shows that it deployed an ran successfully on a `k8s-demo-cluster`.

<img width="1465" height="795" alt="image" src="https://github.com/user-attachments/assets/bef287c8-6293-4b56-99d7-44ce9b9dc5cc" />
