### PR TITLE
deps: bump Telicent UI versions (search, graph, catalog)

### DIFF
--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -60,7 +60,7 @@ dependencies:
     repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: search-ui
-    version: "4.20.0"
+    version: "4.21.0"
     repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: traefik-proxy

--- a/charts/telicent-core/Chart.yaml
+++ b/charts/telicent-core/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
     version: "1.0.9"
     repository: oci://quay.io/telicent/charts
   - name: graph-ui
-    version: "1.38.1"
+    version: "1.38.2"
     repository: oci://quay.io/telicent/charts
     condition: global.enterprise
   - name: query-ui

--- a/charts/telicent-preview/Chart.yaml
+++ b/charts/telicent-preview/Chart.yaml
@@ -27,7 +27,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: data-catalog-ui
-    version: "1.15.4"
+    version: "1.15.5"
     repository: oci://quay.io/telicent/charts
     condition: data-catalog-ui.enabled
   - name: notifications


### PR DESCRIPTION
search-ui from 4.20.0 to 4.21.0 
graph-ui from 1.38.1 to 1.38.2 
catalog-ui from 1.15.4 to 1.15.5