### PR TITLE
feat!: release telicent-core 2.0.0

### DIFF
--- a/charts/telicent-core/README.md
+++ b/charts/telicent-core/README.md
@@ -24,6 +24,28 @@ helm install my-release ./charts/telicent-core
 
 The chart will fail validation if placeholder values are detected or required credentials are missing.
 
+## Upgrading
+
+### To 2.0.0
+
+This release bumps the platform and front-end subcharts to their 2.0.0 platform
+versions. Review the individual subchart changelogs before upgrading:
+
+| Subchart | From | To |
+| --- | --- | --- |
+| `admin-ui` | 1.6.0 | 1.7.1 |
+| `auth` | 0.2.9 | 0.3.1 |
+| `graph` | 1.0.9 | 1.1.4 |
+| `graph-ui` | 1.38.2 | 1.39.0 |
+| `search` | 2.2.0 | 2.2.6 |
+| `search-projector` | 2.2.0 | 2.2.6 |
+| `search-ui` | 4.21.0 | 4.22.1 |
+| `document-pipeline` | 0.2.4 | 0.2.5 |
+| `user-preferences` | 0.2.3 | 0.2.4 |
+
+`document-pipeline` additionally moves its own dependency from 3.5.1 to 4.0.2, and
+`user-preferences` moves its `appVersion` from 2.0.8 to 2.0.10.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:


### PR DESCRIPTION
Forces the telicent-core 2.0.0 release that [#685](https://github.com/Telicent-io/telicent-core-charts/pull/685) was meant to cut.

## Why this is needed

PR #685 was squash-merged under the branch-derived title `Chore/release 2.0.0 (#685)`. release-please only parses that single subject line, so the five real commits — which live in the squash body — were never read. `Chore/release 2.0.0` is not a conventional commit, and the run log confirms it was discarded outright:

```
❯ commit could not be parsed: 5a6169cb Chore/release 2.0.0 (#685)
❯ error message: Error: unexpected token ' ' at 1:14, valid tokens [(, !, :]
...
✔ PR #668 remained the same
```

Zero commits were attributed to any package, so telicent-core stayed at 1.3.4.

## What this PR does

Adds an `## Upgrading` section to the chart README documenting the subchart moves that #685 actually made, and carries a `Release-As: 2.0.0` footer to force the version.

## Merging

This PR is deliberately a **single commit** so the squash-merge default uses the commit message rather than a branch-derived title. Before merging, confirm the squash subject reads `feat!: release telicent-core 2.0.0` and the body still contains the `Release-As: 2.0.0` line.

Once merged, release-please will update the existing open release PR [#668](https://github.com/Telicent-io/telicent-core-charts/pull/668) from 1.3.4 to 2.0.0 — that is the PR to merge to actually cut the release. Do not close #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqB83CwApX71YU8f3DGixq