### PR TITLE
feat!: release telicent-data 1.0.0

### DIFF
--- a/charts/telicent-data/README.md
+++ b/charts/telicent-data/README.md
@@ -27,6 +27,27 @@ To install with custom configuration:
 helm install telicent-data ./charts/telicent-data -f custom-values.yaml
 ```
 
+## Upgrading
+
+### To 1.0.0
+
+First stable release of the chart. This release brings the mapper and producer
+subcharts up to the versions shipped with Telicent Core 2.0.0:
+
+| Subchart | From | To |
+| --- | --- | --- |
+| `ies-regions-ontology-producer` | 0.13.6 | 0.13.7 |
+| `ies-regions-producer` | 0.13.6 | 0.13.7 |
+| `telicent-ontology-adapter` | 0.1.4 | 0.1.5 |
+| `telicent-canonicals-event-document-mapper` | 0.9.11 | 0.9.12 |
+| `telicent-canonicals-event-geo-mapper` | 0.9.11 | 0.9.12 |
+| `telicent-canonicals-event-knowledge-mapper` | 0.9.11 | 0.9.12 |
+| `telicent-canonicals-region-resolver-mapper` | 0.1.3 | 0.1.4 |
+| `telicent-json-validation-mapper` | 0.2.6 | 0.2.7 |
+
+The `telicent-json-validation-mapper` bump applies to both the `canonicals-event`
+and `canonicals-ontology` umbrella charts.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `telicent-data` deployment:


### PR DESCRIPTION
Promotes telicent-data to its first stable release alongside Telicent Core 2.0.0.

## Why this is needed

Two separate reasons telicent-data did not reach 1.0.0 from [#685](https://github.com/Telicent-io/telicent-core-charts/pull/685):

1. #685 was squash-merged under the non-conventional title `Chore/release 2.0.0 (#685)`, which release-please could not parse. The run log shows `charts/telicent-data → commits: 0 → No commits for path, skipping`.
2. Even had it parsed, the three commits in #685 touching `charts/telicent-data` were typed `deps`, which only ever produces a patch bump. No `feat!` touched this path at all.

Separately, `bump-minor-pre-major: true` in `.github/release-please-config.json` means a breaking change alone bumps **minor, not major** for any chart below 1.0.0 — telicent-data would go to 0.4.0, never 1.0.0. That flag is being left as-is by design, so the `Release-As: 1.0.0` footer is required to force the version.

For the record, telicent-data 0.3.9 came from [#686](https://github.com/Telicent-io/telicent-core-charts/pull/686) (`fix: make acled togglable`), not from #685.

## What this PR does

Adds an `## Upgrading` section to the chart README documenting the mapper and producer subchart moves that #685 actually made, and carries a `Release-As: 1.0.0` footer.

## Merging

This PR is deliberately a **single commit** so the squash-merge default uses the commit message rather than a branch-derived title. Before merging, confirm the squash subject reads `feat!: release telicent-data 1.0.0` and the body still contains the `Release-As: 1.0.0` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqB83CwApX71YU8f3DGixq